### PR TITLE
Fix send button enable logic

### DIFF
--- a/content.js
+++ b/content.js
@@ -629,7 +629,12 @@
 
     // Fetch view events
     const promptEl = byId('ctx-original-prompt', false);
-    if (promptEl) promptEl.addEventListener('input', (e) => { state.originalPrompt = e.target.value; resizeTextarea(e.target); });
+    if (promptEl) promptEl.addEventListener('input', (e) => {
+      state.originalPrompt = e.target.value;
+      resizeTextarea(e.target);
+      const submitBtn = byId('ctx-submit', false);
+      if (submitBtn) submitBtn.disabled = state.loading || !state.originalPrompt.trim();
+    });
 
     byId('ctx-toggle-context', false)?.addEventListener('click', () => {
       state.showContextSelection = !state.showContextSelection; render();


### PR DESCRIPTION
Enable the send button immediately on prompt input to fix it remaining disabled after schema selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-29bfb1e2-530c-4ffc-864e-9bce4544f35d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29bfb1e2-530c-4ffc-864e-9bce4544f35d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

